### PR TITLE
Make `encode` return iterator instead of vec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ owning_ref = "0.4"
 prometheus-client-derive-text-encode = { version = "0.3.0", path = "derive-text-encode" }
 prost = { version = "0.9.0", optional = true }
 prost-types = { version = "0.9.0", optional = true }
+void = "1.0"
 
 [dev-dependencies]
 async-std = { version = "1", features = ["attributes"] }

--- a/src/encoding/proto.rs
+++ b/src/encoding/proto.rs
@@ -38,6 +38,7 @@ use crate::registry::Registry;
 use std::collections::HashMap;
 use std::ops::Deref;
 use std::vec::IntoIter;
+use void::Void;
 
 pub fn encode<M>(registry: &Registry<M>) -> openmetrics_data_model::MetricSet
 where
@@ -156,6 +157,14 @@ where
 
     fn encode(self) -> Self::Iterator {
         Box::new(self.iter().map(|t| t.into()))
+    }
+}
+
+impl<'a> EncodeLabels for &'a Void {
+    type Iterator = Box<dyn Iterator<Item = openmetrics_data_model::Label>>;
+
+    fn encode(self) -> Self::Iterator {
+        unreachable!()
     }
 }
 
@@ -361,11 +370,8 @@ impl EncodeMetric for Histogram {
 
     fn encode(&self, labels: Vec<openmetrics_data_model::Label>) -> Self::Iterator {
         let (sum, count, buckets) = self.get();
-        // TODO: Would be better to use never type instead of `()`.
-        // TODO: Revert (String, String)?
-        let mut metric = encode_histogram_with_maybe_exemplars::<Vec<(String, String)>>(
-            sum, count, &buckets, None,
-        );
+        // TODO: Would be better to use never type instead of `Void`.
+        let mut metric = encode_histogram_with_maybe_exemplars::<Void>(sum, count, &buckets, None);
         metric.labels = labels;
         std::iter::once(metric)
     }

--- a/src/encoding/proto.rs
+++ b/src/encoding/proto.rs
@@ -77,19 +77,23 @@ impl From<MetricType> for openmetrics_data_model::MetricType {
 
 /// Trait implemented by each metric type, e.g. [`Counter`], to implement its encoding.
 pub trait EncodeMetric {
+    type Iterator: Iterator<Item = openmetrics_data_model::Metric>;
+
     fn encode(
         &self,
         labels: Vec<openmetrics_data_model::Label>,
-    ) -> Vec<openmetrics_data_model::Metric>;
+    ) -> Self::Iterator;
 
     fn metric_type(&self) -> MetricType;
 }
 
-impl EncodeMetric for Box<dyn EncodeMetric> {
+impl<'a> EncodeMetric for Box<dyn EncodeMetric<Iterator = std::slice::Iter<'a, openmetrics_data_model::Metric>>> {
+    type Iterator = std::slice::Iter<'a, openmetrics_data_model::Metric>;
+    
     fn encode(
         &self,
         labels: Vec<openmetrics_data_model::Label>,
-    ) -> Vec<openmetrics_data_model::Metric> {
+    ) -> Self::Iterator {
         self.deref().encode(labels)
     }
 
@@ -102,11 +106,13 @@ pub trait SendEncodeMetric: EncodeMetric + Send {}
 
 impl<T: EncodeMetric + Send> SendEncodeMetric for T {}
 
-impl EncodeMetric for Box<dyn SendEncodeMetric> {
+impl<'a> EncodeMetric for Box<dyn SendEncodeMetric<Iterator = std::slice::Iter<'a, openmetrics_data_model::Metric>>> {
+    type Iterator = std::slice::Iter<'a, openmetrics_data_model::Metric>;
+
     fn encode(
         &self,
         labels: Vec<openmetrics_data_model::Label>,
-    ) -> Vec<openmetrics_data_model::Metric> {
+    ) -> Self::Iterator {
         self.deref().encode(labels)
     }
 
@@ -183,14 +189,16 @@ where
     N: EncodeCounterValue,
     A: counter::Atomic<N>,
 {
+    type Iterator = std::slice::Iter<'a, openmetrics_data_model::Metric>;
+
     fn encode(
         &self,
         labels: Vec<openmetrics_data_model::Label>,
-    ) -> Vec<openmetrics_data_model::Metric> {
+    ) -> Self::Iterator {
         let mut metric = encode_counter_with_maybe_exemplar(self.get(), None);
         metric.labels = labels;
 
-        vec![metric]
+        vec![metric].iter()
     }
 
     fn metric_type(&self) -> MetricType {
@@ -198,17 +206,19 @@ where
     }
 }
 
-impl<S, N, A> EncodeMetric for CounterWithExemplar<S, N, A>
+impl<'a, S, N, A> EncodeMetric for CounterWithExemplar<S, N, A>
 where
     S: EncodeLabel,
     N: Clone + EncodeCounterValue,
     A: counter::Atomic<N>,
     f64: From<N>,
 {
+    type Iterator = std::slice::Iter<'a, openmetrics_data_model::Metric>;
+
     fn encode(
         &self,
         labels: Vec<openmetrics_data_model::Label>,
-    ) -> Vec<openmetrics_data_model::Metric> {
+    ) -> Self::Iterator {
         let (value, exemplar) = self.get();
 
         let exemplar_proto = if let Some(e) = exemplar.as_ref() {
@@ -220,7 +230,7 @@ where
         let mut metric = encode_counter_with_maybe_exemplar(value.clone(), exemplar_proto);
         metric.labels = labels;
 
-        vec![metric]
+        vec![metric].iter()
     }
 
     fn metric_type(&self) -> MetricType {
@@ -275,15 +285,17 @@ impl EncodeGaugeValue for f64 {
     }
 }
 
-impl<N, A> EncodeMetric for Gauge<N, A>
+impl<'a, N, A> EncodeMetric for Gauge<N, A>
 where
     N: EncodeGaugeValue,
     A: gauge::Atomic<N>,
 {
+    type Iterator = std::slice::Iter<'a, openmetrics_data_model::Metric>;
+
     fn encode(
         &self,
         labels: Vec<openmetrics_data_model::Label>,
-    ) -> Vec<openmetrics_data_model::Metric> {
+    ) -> Self::Iterator {
         let mut metric = openmetrics_data_model::Metric::default();
 
         metric.metric_points = {
@@ -301,7 +313,7 @@ where
         };
 
         metric.labels = labels;
-        vec![metric]
+        vec![metric].iter()
     }
 
     fn metric_type(&self) -> MetricType {
@@ -312,16 +324,18 @@ where
 /////////////////////////////////////////////////////////////////////////////////
 // Family
 
-impl<S, M, C> EncodeMetric for Family<S, M, C>
+impl<'a, S, M, C> EncodeMetric for Family<S, M, C>
 where
     S: Clone + std::hash::Hash + Eq + EncodeLabel,
     M: EncodeMetric + TypedMetric,
     C: MetricConstructor<M>,
 {
+    type Iterator = std::slice::Iter<'a, openmetrics_data_model::Metric>;
+
     fn encode(
         &self,
         labels: Vec<openmetrics_data_model::Label>,
-    ) -> Vec<openmetrics_data_model::Metric> {
+    ) -> Self::Iterator {
         let mut metrics = vec![];
 
         let guard = self.read();
@@ -331,7 +345,7 @@ where
             metrics.extend(metric.encode(label));
         }
 
-        metrics
+        metrics.iter()
     }
 
     fn metric_type(&self) -> MetricType {
@@ -342,16 +356,18 @@ where
 /////////////////////////////////////////////////////////////////////////////////
 // Histogram
 
-impl EncodeMetric for Histogram {
+impl<'a> EncodeMetric for Histogram {
+    type Iterator = std::slice::Iter<'a, openmetrics_data_model::Metric>;
+
     fn encode(
         &self,
         labels: Vec<openmetrics_data_model::Label>,
-    ) -> Vec<openmetrics_data_model::Metric> {
+    ) -> Self::Iterator {
         let (sum, count, buckets) = self.get();
         // TODO: Would be better to use never type instead of `()`.
         let mut metric = encode_histogram_with_maybe_exemplars::<()>(sum, count, &buckets, None);
         metric.labels = labels;
-        vec![metric]
+        vec![metric].iter()
     }
 
     fn metric_type(&self) -> MetricType {
@@ -359,20 +375,22 @@ impl EncodeMetric for Histogram {
     }
 }
 
-impl<S> EncodeMetric for HistogramWithExemplars<S>
+impl<'a, S> EncodeMetric for HistogramWithExemplars<S>
 where
     S: EncodeLabel,
 {
+    type Iterator = std::slice::Iter<'a, openmetrics_data_model::Metric>;
+
     fn encode(
         &self,
         labels: Vec<openmetrics_data_model::Label>,
-    ) -> Vec<openmetrics_data_model::Metric> {
+    ) -> Self::Iterator {
         let inner = self.inner();
         let (sum, count, buckets) = inner.histogram.get();
         let mut metric =
             encode_histogram_with_maybe_exemplars(sum, count, &buckets, Some(&inner.exemplars));
         metric.labels = labels;
-        vec![metric]
+        vec![metric].iter()
     }
 
     fn metric_type(&self) -> MetricType {
@@ -423,14 +441,16 @@ fn encode_histogram_with_maybe_exemplars<S: EncodeLabel>(
 /////////////////////////////////////////////////////////////////////////////////
 // Info
 
-impl<S> EncodeMetric for Info<S>
+impl<'a, S> EncodeMetric for Info<S>
 where
     S: EncodeLabel,
 {
+    type Iterator = std::slice::Iter<'a, openmetrics_data_model::Metric>;
+
     fn encode(
         &self,
         labels: Vec<openmetrics_data_model::Label>,
-    ) -> Vec<openmetrics_data_model::Metric> {
+    ) -> Self::Iterator {
         let mut metric = openmetrics_data_model::Metric::default();
 
         metric.metric_points = {
@@ -450,7 +470,7 @@ where
             vec![metric_point]
         };
 
-        vec![metric]
+        vec![metric].iter()
     }
 
     fn metric_type(&self) -> MetricType {

--- a/src/encoding/proto.rs
+++ b/src/encoding/proto.rs
@@ -705,12 +705,12 @@ mod tests {
 
         let metric = family.metrics.first().unwrap();
         assert_eq!(3, metric.labels.len());
-        assert_eq!("method", metric.labels[0].name);
-        assert_eq!("GET", metric.labels[0].value);
-        assert_eq!("status", metric.labels[1].name);
-        assert_eq!("200", metric.labels[1].value);
-        assert_eq!("my_key", metric.labels[2].name);
-        assert_eq!("my_value", metric.labels[2].value);
+        assert_eq!("my_key", metric.labels[0].name);
+        assert_eq!("my_value", metric.labels[0].value);
+        assert_eq!("method", metric.labels[1].name);
+        assert_eq!("GET", metric.labels[1].value);
+        assert_eq!("status", metric.labels[2].name);
+        assert_eq!("200", metric.labels[2].value);
 
         match extract_metric_point_value(metric_set) {
             openmetrics_data_model::metric_point::Value::CounterValue(value) => {

--- a/src/encoding/proto.rs
+++ b/src/encoding/proto.rs
@@ -121,8 +121,7 @@ impl EncodeMetric
     }
 }
 
-// TODO: Rename to EncodeLabels?
-pub trait EncodeLabel {
+pub trait EncodeLabels {
     type Iterator: Iterator<Item = openmetrics_data_model::Label>;
 
     fn encode(self) -> Self::Iterator;
@@ -138,7 +137,7 @@ impl<K: ToString, V: ToString> Into<openmetrics_data_model::Label> for &(K, V) {
 }
 
 // TODO: Is this needed? We already have `&'a [T]` below.
-impl<'a, T> EncodeLabel for &'a Vec<T>
+impl<'a, T> EncodeLabels for &'a Vec<T>
 where
     for<'b> &'b T: Into<openmetrics_data_model::Label>,
 {
@@ -149,7 +148,7 @@ where
     }
 }
 
-impl<'a, T> EncodeLabel for &'a [T]
+impl<'a, T> EncodeLabels for &'a [T]
 where
     for<'b> &'b T: Into<openmetrics_data_model::Label>,
 {
@@ -163,7 +162,7 @@ where
 fn encode_exemplar<S, N>(exemplar: &Exemplar<S, N>) -> openmetrics_data_model::Exemplar
 where
     N: Clone,
-    for<'a> &'a S: EncodeLabel,
+    for<'a> &'a S: EncodeLabels,
     f64: From<N>, // required because Exemplar.value is defined as `double` in protobuf
 {
     let mut exemplar_proto = openmetrics_data_model::Exemplar::default();
@@ -213,7 +212,7 @@ where
 
 impl<'a, S, N, A> EncodeMetric for CounterWithExemplar<S, N, A>
 where
-    for<'b> &'b S: EncodeLabel,
+    for<'b> &'b S: EncodeLabels,
     N: Clone + EncodeCounterValue,
     A: counter::Atomic<N>,
     f64: From<N>,
@@ -326,7 +325,7 @@ where
 impl<S, M, C> EncodeMetric for Family<S, M, C>
 where
     S: Clone + std::hash::Hash + Eq,
-    for<'b> &'b S: EncodeLabel,
+    for<'b> &'b S: EncodeLabels,
     M: EncodeMetric + TypedMetric,
     C: MetricConstructor<M>,
 {
@@ -378,7 +377,7 @@ impl EncodeMetric for Histogram {
 
 impl<S> EncodeMetric for HistogramWithExemplars<S>
 where
-    for<'b> &'b S: EncodeLabel,
+    for<'b> &'b S: EncodeLabels,
 {
     type Iterator = std::iter::Once<openmetrics_data_model::Metric>;
 
@@ -403,7 +402,7 @@ fn encode_histogram_with_maybe_exemplars<'a, S>(
     exemplars: Option<&'a HashMap<usize, Exemplar<S, f64>>>,
 ) -> openmetrics_data_model::Metric
 where
-    for<'b> &'b S: EncodeLabel,
+    for<'b> &'b S: EncodeLabels,
 {
     let mut metric = openmetrics_data_model::Metric::default();
 
@@ -444,7 +443,7 @@ where
 
 impl<S> EncodeMetric for Info<S>
 where
-    for<'b> &'b S: EncodeLabel,
+    for<'b> &'b S: EncodeLabels,
 {
     type Iterator = std::iter::Once<openmetrics_data_model::Metric>;
 

--- a/src/encoding/proto.rs
+++ b/src/encoding/proto.rs
@@ -56,7 +56,9 @@ where
             family.unit = unit.as_str().to_string();
         }
         family.help = desc.help().to_string();
-        family.metrics = metric.encode(desc.labels().encode()).collect::<Vec<_>>();
+        family.metrics = metric
+            .encode(desc.labels().encode().collect::<Vec<_>>())
+            .collect::<Vec<_>>();
 
         metric_set.metric_families.push(family);
     }
@@ -116,33 +118,51 @@ impl EncodeMetric
 }
 
 pub trait EncodeLabel {
-    fn encode(&self) -> Vec<openmetrics_data_model::Label>;
+    type Iterator: Iterator<Item = openmetrics_data_model::Label>;
+
+    fn encode(&self) -> Self::Iterator;
 }
 
 impl<K: ToString, V: ToString> EncodeLabel for (K, V) {
-    fn encode(&self) -> Vec<openmetrics_data_model::Label> {
+    type Iterator = IntoIter<openmetrics_data_model::Label>;
+
+    fn encode(&self) -> Self::Iterator {
         let mut label = openmetrics_data_model::Label::default();
         label.name = self.0.to_string();
         label.value = self.1.to_string();
-        vec![label]
+        vec![label].into_iter()
     }
 }
 
 impl<T: EncodeLabel> EncodeLabel for Vec<T> {
-    fn encode(&self) -> Vec<openmetrics_data_model::Label> {
-        self.iter().map(|t| t.encode()).flatten().collect()
+    type Iterator = IntoIter<openmetrics_data_model::Label>;
+
+    fn encode(&self) -> Self::Iterator {
+        self.iter()
+            .map(|t| t.encode())
+            .flatten()
+            .collect::<Vec<_>>()
+            .into_iter()
     }
 }
 
 impl<T: EncodeLabel> EncodeLabel for &[T] {
-    fn encode(&self) -> Vec<openmetrics_data_model::Label> {
-        self.iter().map(|t| t.encode()).flatten().collect()
+    type Iterator = IntoIter<openmetrics_data_model::Label>;
+
+    fn encode(&self) -> Self::Iterator {
+        self.iter()
+            .map(|t| t.encode())
+            .flatten()
+            .collect::<Vec<_>>()
+            .into_iter()
     }
 }
 
 impl EncodeLabel for () {
-    fn encode(&self) -> Vec<openmetrics_data_model::Label> {
-        vec![]
+    type Iterator = IntoIter<openmetrics_data_model::Label>;
+
+    fn encode(&self) -> Self::Iterator {
+        vec![].into_iter()
     }
 }
 
@@ -154,7 +174,7 @@ where
 {
     let mut exemplar_proto = openmetrics_data_model::Exemplar::default();
     exemplar_proto.value = exemplar.value.clone().into();
-    exemplar_proto.label = exemplar.label_set.encode();
+    exemplar_proto.label = exemplar.label_set.encode().collect::<Vec<_>>();
 
     exemplar_proto
 }
@@ -322,7 +342,7 @@ where
 
         let guard = self.read();
         for (label_set, metric) in guard.iter() {
-            let mut label = label_set.encode();
+            let mut label = label_set.encode().collect::<Vec<_>>();
             label.append(&mut labels.clone());
             metrics.extend(metric.encode(label));
         }
@@ -429,7 +449,7 @@ where
         metric.metric_points = {
             let mut metric_point = openmetrics_data_model::MetricPoint::default();
             metric_point.value = {
-                let mut label = self.0.encode();
+                let mut label = self.0.encode().collect::<Vec<_>>();
                 label.append(&mut labels.clone());
 
                 let mut info_value = openmetrics_data_model::InfoValue::default();

--- a/src/encoding/proto.rs
+++ b/src/encoding/proto.rs
@@ -87,8 +87,10 @@ pub trait EncodeMetric {
     fn metric_type(&self) -> MetricType;
 }
 
-impl EncodeMetric for Box<dyn EncodeMetric<Iterator = IntoIter<openmetrics_data_model::Metric>>> {
-    type Iterator = IntoIter<openmetrics_data_model::Metric>;
+impl EncodeMetric
+    for Box<dyn EncodeMetric<Iterator = Box<dyn Iterator<Item = openmetrics_data_model::Metric>>>>
+{
+    type Iterator = Box<dyn Iterator<Item = openmetrics_data_model::Metric>>;
 
     fn encode(&self, labels: Vec<openmetrics_data_model::Label>) -> Self::Iterator {
         self.deref().encode(labels)
@@ -104,9 +106,11 @@ pub trait SendEncodeMetric: EncodeMetric + Send {}
 impl<T: EncodeMetric + Send> SendEncodeMetric for T {}
 
 impl EncodeMetric
-    for Box<dyn SendEncodeMetric<Iterator = IntoIter<openmetrics_data_model::Metric>>>
+    for Box<
+        dyn SendEncodeMetric<Iterator = Box<dyn Iterator<Item = openmetrics_data_model::Metric>>>,
+    >
 {
-    type Iterator = IntoIter<openmetrics_data_model::Metric>;
+    type Iterator = Box<dyn Iterator<Item = openmetrics_data_model::Metric>>;
 
     fn encode(&self, labels: Vec<openmetrics_data_model::Label>) -> Self::Iterator {
         self.deref().encode(labels)
@@ -117,59 +121,49 @@ impl EncodeMetric
     }
 }
 
+// TODO: Rename to EncodeLabels?
 pub trait EncodeLabel {
     type Iterator: Iterator<Item = openmetrics_data_model::Label>;
 
-    fn encode(&self) -> Self::Iterator;
+    fn encode(self) -> Self::Iterator;
 }
 
-impl<K: ToString, V: ToString> EncodeLabel for (K, V) {
-    type Iterator = IntoIter<openmetrics_data_model::Label>;
-
-    fn encode(&self) -> Self::Iterator {
+impl<K: ToString, V: ToString> Into<openmetrics_data_model::Label> for &(K, V) {
+    fn into(self) -> openmetrics_data_model::Label {
         let mut label = openmetrics_data_model::Label::default();
         label.name = self.0.to_string();
         label.value = self.1.to_string();
-        vec![label].into_iter()
+        label
     }
 }
 
-impl<T: EncodeLabel> EncodeLabel for Vec<T> {
-    type Iterator = IntoIter<openmetrics_data_model::Label>;
+// TODO: Is this needed? We already have `&'a [T]` below.
+impl<'a, T> EncodeLabel for &'a Vec<T>
+where
+    for<'b> &'b T: Into<openmetrics_data_model::Label>,
+{
+    type Iterator = Box<dyn Iterator<Item = openmetrics_data_model::Label> + 'a>;
 
-    fn encode(&self) -> Self::Iterator {
-        self.iter()
-            .map(|t| t.encode())
-            .flatten()
-            .collect::<Vec<_>>()
-            .into_iter()
+    fn encode(self) -> Self::Iterator {
+        Box::new(self.iter().map(|t| t.into()))
     }
 }
 
-impl<T: EncodeLabel> EncodeLabel for &[T] {
-    type Iterator = IntoIter<openmetrics_data_model::Label>;
+impl<'a, T> EncodeLabel for &'a [T]
+where
+    for<'b> &'b T: Into<openmetrics_data_model::Label>,
+{
+    type Iterator = Box<dyn Iterator<Item = openmetrics_data_model::Label> + 'a>;
 
-    fn encode(&self) -> Self::Iterator {
-        self.iter()
-            .map(|t| t.encode())
-            .flatten()
-            .collect::<Vec<_>>()
-            .into_iter()
-    }
-}
-
-impl EncodeLabel for () {
-    type Iterator = IntoIter<openmetrics_data_model::Label>;
-
-    fn encode(&self) -> Self::Iterator {
-        vec![].into_iter()
+    fn encode(self) -> Self::Iterator {
+        Box::new(self.iter().map(|t| t.into()))
     }
 }
 
 fn encode_exemplar<S, N>(exemplar: &Exemplar<S, N>) -> openmetrics_data_model::Exemplar
 where
     N: Clone,
-    S: EncodeLabel,
+    for<'a> &'a S: EncodeLabel,
     f64: From<N>, // required because Exemplar.value is defined as `double` in protobuf
 {
     let mut exemplar_proto = openmetrics_data_model::Exemplar::default();
@@ -203,13 +197,13 @@ where
     N: EncodeCounterValue,
     A: counter::Atomic<N>,
 {
-    type Iterator = IntoIter<openmetrics_data_model::Metric>;
+    type Iterator = std::iter::Once<openmetrics_data_model::Metric>;
 
     fn encode(&self, labels: Vec<openmetrics_data_model::Label>) -> Self::Iterator {
         let mut metric = encode_counter_with_maybe_exemplar(self.get(), None);
         metric.labels = labels;
 
-        vec![metric].into_iter()
+        std::iter::once(metric)
     }
 
     fn metric_type(&self) -> MetricType {
@@ -217,14 +211,14 @@ where
     }
 }
 
-impl<S, N, A> EncodeMetric for CounterWithExemplar<S, N, A>
+impl<'a, S, N, A> EncodeMetric for CounterWithExemplar<S, N, A>
 where
-    S: EncodeLabel,
+    for<'b> &'b S: EncodeLabel,
     N: Clone + EncodeCounterValue,
     A: counter::Atomic<N>,
     f64: From<N>,
 {
-    type Iterator = IntoIter<openmetrics_data_model::Metric>;
+    type Iterator = std::iter::Once<openmetrics_data_model::Metric>;
 
     fn encode(&self, labels: Vec<openmetrics_data_model::Label>) -> Self::Iterator {
         let (value, exemplar) = self.get();
@@ -238,7 +232,7 @@ where
         let mut metric = encode_counter_with_maybe_exemplar(value.clone(), exemplar_proto);
         metric.labels = labels;
 
-        vec![metric].into_iter()
+        std::iter::once(metric)
     }
 
     fn metric_type(&self) -> MetricType {
@@ -293,12 +287,12 @@ impl EncodeGaugeValue for f64 {
     }
 }
 
-impl<N, A> EncodeMetric for Gauge<N, A>
+impl<'a, N, A> EncodeMetric for Gauge<N, A>
 where
     N: EncodeGaugeValue,
     A: gauge::Atomic<N>,
 {
-    type Iterator = IntoIter<openmetrics_data_model::Metric>;
+    type Iterator = std::iter::Once<openmetrics_data_model::Metric>;
 
     fn encode(&self, labels: Vec<openmetrics_data_model::Label>) -> Self::Iterator {
         let mut metric = openmetrics_data_model::Metric::default();
@@ -318,7 +312,7 @@ where
         };
 
         metric.labels = labels;
-        vec![metric].into_iter()
+        std::iter::once(metric)
     }
 
     fn metric_type(&self) -> MetricType {
@@ -329,25 +323,30 @@ where
 /////////////////////////////////////////////////////////////////////////////////
 // Family
 
-impl<S, M, C> EncodeMetric for Family<S, M, C>
+impl<'c, S, M, C> EncodeMetric for Family<S, M, C>
 where
-    S: Clone + std::hash::Hash + Eq + EncodeLabel,
+    S: Clone + std::hash::Hash + Eq,
+    for<'b> &'b S: EncodeLabel,
     M: EncodeMetric + TypedMetric,
     C: MetricConstructor<M>,
 {
     type Iterator = IntoIter<openmetrics_data_model::Metric>;
 
     fn encode(&self, labels: Vec<openmetrics_data_model::Label>) -> Self::Iterator {
-        let mut metrics = vec![];
-
-        let guard = self.read();
-        for (label_set, metric) in guard.iter() {
-            let mut label = label_set.encode().collect::<Vec<_>>();
-            label.append(&mut labels.clone());
-            metrics.extend(metric.encode(label));
-        }
-
-        metrics.into_iter()
+        self.read()
+            .iter()
+            .map(|(label_set, metric)| {
+                let mut labels = labels.clone();
+                labels.extend(label_set.encode());
+                metric.encode(labels)
+            })
+            .flatten()
+            // TODO: Ideally we would not have to collect into a vector here,
+            // though we have to as we borrow from the `MutexGuard`. Once
+            // https://github.com/prometheus/client_rust/pull/78/ merged, we
+            // might be able to leverage `MutexGuard::map`.
+            .collect::<Vec<_>>()
+            .into_iter()
     }
 
     fn metric_type(&self) -> MetricType {
@@ -359,14 +358,17 @@ where
 // Histogram
 
 impl EncodeMetric for Histogram {
-    type Iterator = IntoIter<openmetrics_data_model::Metric>;
+    type Iterator = std::iter::Once<openmetrics_data_model::Metric>;
 
     fn encode(&self, labels: Vec<openmetrics_data_model::Label>) -> Self::Iterator {
         let (sum, count, buckets) = self.get();
         // TODO: Would be better to use never type instead of `()`.
-        let mut metric = encode_histogram_with_maybe_exemplars::<()>(sum, count, &buckets, None);
+        // TODO: Revert (String, String)?
+        let mut metric = encode_histogram_with_maybe_exemplars::<Vec<(String, String)>>(
+            sum, count, &buckets, None,
+        );
         metric.labels = labels;
-        vec![metric].into_iter()
+        std::iter::once(metric)
     }
 
     fn metric_type(&self) -> MetricType {
@@ -376,9 +378,9 @@ impl EncodeMetric for Histogram {
 
 impl<S> EncodeMetric for HistogramWithExemplars<S>
 where
-    S: EncodeLabel,
+    for<'b> &'b S: EncodeLabel,
 {
-    type Iterator = IntoIter<openmetrics_data_model::Metric>;
+    type Iterator = std::iter::Once<openmetrics_data_model::Metric>;
 
     fn encode(&self, labels: Vec<openmetrics_data_model::Label>) -> Self::Iterator {
         let inner = self.inner();
@@ -386,7 +388,7 @@ where
         let mut metric =
             encode_histogram_with_maybe_exemplars(sum, count, &buckets, Some(&inner.exemplars));
         metric.labels = labels;
-        vec![metric].into_iter()
+        std::iter::once(metric)
     }
 
     fn metric_type(&self) -> MetricType {
@@ -394,12 +396,15 @@ where
     }
 }
 
-fn encode_histogram_with_maybe_exemplars<S: EncodeLabel>(
+fn encode_histogram_with_maybe_exemplars<'a, S>(
     sum: f64,
     count: u64,
     buckets: &[(f64, u64)],
-    exemplars: Option<&HashMap<usize, Exemplar<S, f64>>>,
-) -> openmetrics_data_model::Metric {
+    exemplars: Option<&'a HashMap<usize, Exemplar<S, f64>>>,
+) -> openmetrics_data_model::Metric
+where
+    for<'b> &'b S: EncodeLabel,
+{
     let mut metric = openmetrics_data_model::Metric::default();
 
     metric.metric_points = {
@@ -439,21 +444,20 @@ fn encode_histogram_with_maybe_exemplars<S: EncodeLabel>(
 
 impl<S> EncodeMetric for Info<S>
 where
-    S: EncodeLabel,
+    for<'b> &'b S: EncodeLabel,
 {
-    type Iterator = IntoIter<openmetrics_data_model::Metric>;
+    type Iterator = std::iter::Once<openmetrics_data_model::Metric>;
 
-    fn encode(&self, labels: Vec<openmetrics_data_model::Label>) -> Self::Iterator {
+    fn encode(&self, mut labels: Vec<openmetrics_data_model::Label>) -> Self::Iterator {
         let mut metric = openmetrics_data_model::Metric::default();
 
         metric.metric_points = {
             let mut metric_point = openmetrics_data_model::MetricPoint::default();
             metric_point.value = {
-                let mut label = self.0.encode().collect::<Vec<_>>();
-                label.append(&mut labels.clone());
+                labels.extend(self.0.encode());
 
                 let mut info_value = openmetrics_data_model::InfoValue::default();
-                info_value.info = label;
+                info_value.info = labels;
 
                 Some(openmetrics_data_model::metric_point::Value::InfoValue(
                     info_value,
@@ -463,7 +467,7 @@ where
             vec![metric_point]
         };
 
-        vec![metric].into_iter()
+        std::iter::once(metric)
     }
 
     fn metric_type(&self) -> MetricType {
@@ -562,7 +566,7 @@ mod tests {
     fn encode_counter_with_exemplar() {
         let mut registry = Registry::default();
 
-        let counter_with_exemplar: CounterWithExemplar<(String, f64), f64> =
+        let counter_with_exemplar: CounterWithExemplar<Vec<(String, f64)>, f64> =
             CounterWithExemplar::default();
         registry.register(
             "my_counter_with_exemplar",
@@ -570,7 +574,7 @@ mod tests {
             counter_with_exemplar.clone(),
         );
 
-        counter_with_exemplar.inc_by(1.0, Some(("user_id".to_string(), 42.0)));
+        counter_with_exemplar.inc_by(1.0, Some(vec![("user_id".to_string(), 42.0)]));
 
         let metric_set = encode(&registry);
 
@@ -757,7 +761,7 @@ mod tests {
         let mut registry = Registry::default();
         let histogram = HistogramWithExemplars::new(exponential_buckets(1.0, 2.0, 10));
         registry.register("my_histogram", "My histogram", histogram.clone());
-        histogram.observe(1.0, Some(("user_id".to_string(), 42u64)));
+        histogram.observe(1.0, Some(vec![("user_id".to_string(), 42u64)]));
 
         let metric_set = encode(&registry);
 

--- a/src/encoding/proto.rs
+++ b/src/encoding/proto.rs
@@ -323,7 +323,7 @@ where
 /////////////////////////////////////////////////////////////////////////////////
 // Family
 
-impl<'c, S, M, C> EncodeMetric for Family<S, M, C>
+impl<S, M, C> EncodeMetric for Family<S, M, C>
 where
     S: Clone + std::hash::Hash + Eq,
     for<'b> &'b S: EncodeLabel,


### PR DESCRIPTION
This branch is based on `protobuf-support`. Ref: https://github.com/prometheus/client_rust/pull/47